### PR TITLE
Remove slash

### DIFF
--- a/src/Laracasts/Crawler.php
+++ b/src/Laracasts/Crawler.php
@@ -30,7 +30,7 @@ class Crawler
         $crawler->filter('div.conversation-list-item')->each(function (BaseCrawler $listItem) use ($results) {
             $result = (new Result(
                 $listItem->filter('a.conversation-list-link')->first()->text(),
-                static::BASE_URL . $listItem->filter('a.conversation-list-link')->first()->attr('href')
+                static::BASE_URL . substr($listItem->filter('a.conversation-list-link')->first()->attr('href'), 1)
             ))->byAuthor(
                 $listItem->filter('.conversation-list-title div a.tw-uppercase')->first()->text(),
                 $listItem->filter('.conversation-list-title div a.tw-uppercase')->first()->attr('href')


### PR DESCRIPTION
I noticed that the thread links included a double slash. For example:

https://laracasts.com//discuss/channels/laravel/exception-handler-response

This PR fixes that by removing the opening slash from the href of the link.